### PR TITLE
feat: OAuth2 jwt refresh

### DIFF
--- a/src/main/java/com/potential_radar/PR/common/excetpion/ErrorResponse.java
+++ b/src/main/java/com/potential_radar/PR/common/excetpion/ErrorResponse.java
@@ -1,0 +1,12 @@
+package com.potential_radar.PR.common.excetpion;
+
+import lombok.Getter;
+
+@Getter
+public class ErrorResponse {
+    private final String message;
+
+    public ErrorResponse(String message) {
+        this.message = message;
+    }
+}

--- a/src/main/java/com/potential_radar/PR/common/excetpion/GlobalExceptionHandler.java
+++ b/src/main/java/com/potential_radar/PR/common/excetpion/GlobalExceptionHandler.java
@@ -5,32 +5,45 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
-import java.util.Map;
-
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
     @ExceptionHandler(NotFoundException.class)
-    public ResponseEntity<Map<String, String>> handleNotFoundException(NotFoundException ex) {
+    public ResponseEntity<ErrorResponse> handleNotFoundException(NotFoundException ex) {
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(
-                Map.of("message", ex.getMessage())
+                new ErrorResponse(ex.getMessage())
         );
     }
 
     @ExceptionHandler(IllegalArgumentException.class)
-    public ResponseEntity<Map<String, String>> handleIllegalArgument(IllegalArgumentException ex) {
-        return ResponseEntity.badRequest().body(
-                Map.of("message", ex.getMessage())
-        );
+    public ResponseEntity<ErrorResponse> handleIllegalArgument(IllegalArgumentException ex) {
+        String message = ex.getMessage();
+
+        // 로그인 실패 (존재하지 않는 사용자, 비밀번호 불일치) -> 401 Unauthorized
+        if (message.contains("존재하지 않는 사용자") || message.contains("비밀번호가 일치하지 않습니다")) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(new ErrorResponse(message));
+        }
+
+        // 이메일 중복과 같은 비즈니스 규칙 위반은 409 Conflict가 더 적절.
+        if (message.contains("이미 가입된 이메일")) {
+            return ResponseEntity.status(HttpStatus.CONFLICT).body(new ErrorResponse(message));
+        }
+        // 그 외 일반적인 잘못된 인수는 400 Bad Request를 반환합니다.
+        return ResponseEntity.badRequest().body(new ErrorResponse(message));
+    }
+
+    @ExceptionHandler(InvalidTokenException.class)
+    public ResponseEntity<ErrorResponse> handleInvalidTokenException(InvalidTokenException ex) {
+        // 유효하지 않은 토큰 관련 예외는 401 Unauthorized
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(new ErrorResponse(ex.getMessage()));
     }
 
     @ExceptionHandler(Exception.class)
-    public ResponseEntity<Map<String, String>> handleAll(Exception ex) {
+    public ResponseEntity<ErrorResponse> handleAll(Exception ex) {
         ex.printStackTrace();
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(
-                Map.of("message", "서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요.")
+                new ErrorResponse("서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요.")
         );
     }
 
 }
-

--- a/src/main/java/com/potential_radar/PR/common/excetpion/InvalidTokenException.java
+++ b/src/main/java/com/potential_radar/PR/common/excetpion/InvalidTokenException.java
@@ -1,0 +1,7 @@
+package com.potential_radar.PR.common.excetpion;
+
+public class InvalidTokenException extends RuntimeException {
+    public InvalidTokenException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/potential_radar/PR/config/jwt/JwtProperties.java
+++ b/src/main/java/com/potential_radar/PR/config/jwt/JwtProperties.java
@@ -13,4 +13,6 @@ public class JwtProperties {
 
     private String issuer;
     private String secretKey;
+    private Long accessTokenExpiration;
+    private Long refreshTokenExpiration;
 }

--- a/src/main/java/com/potential_radar/PR/config/jwt/JwtProperties.java
+++ b/src/main/java/com/potential_radar/PR/config/jwt/JwtProperties.java
@@ -1,15 +1,37 @@
 package com.potential_radar.PR.config.jwt;
 
+import jakarta.annotation.PostConstruct;
 import lombok.Getter;
 import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 
 @Getter
 @Setter
 @Component
+@Slf4j
 @ConfigurationProperties(prefix = "jwt")
 public class JwtProperties {
+
+    @PostConstruct
+    public void validate() {
+        if (issuer == null || issuer.isBlank()) {
+            throw new IllegalStateException("jwt.issuer 속성을 설정해주세요.");
+        }
+        if (secretKey == null || secretKey.isBlank()) {
+            throw new IllegalStateException("jwt.secret-key 속성을 설정해주세요.");
+        }
+        if (accessTokenExpiration == null || accessTokenExpiration <= 0) {
+            throw new IllegalStateException("Access 토큰 만료 시간(jwt.access-token-expiration)은 양수여야 합니다.");
+        }
+        if (refreshTokenExpiration == null || refreshTokenExpiration <= 0) {
+            throw new IllegalStateException("Refresh 토큰 만료 시간(jwt.refresh-token-expiration)은 양수여야 합니다.");
+        }
+        if (refreshTokenExpiration <= accessTokenExpiration) {
+            log.warn("경고: Refresh 토큰의 만료 시간은 Access 토큰의 만료 시간보다 길게 설정하는 것이 좋습니다.");
+        }
+    }
 
     private String issuer;
     private String secretKey;

--- a/src/main/java/com/potential_radar/PR/config/jwt/TokenProvider.java
+++ b/src/main/java/com/potential_radar/PR/config/jwt/TokenProvider.java
@@ -1,9 +1,9 @@
 package com.potential_radar.PR.config.jwt;
 
-import com.potential_radar.PR.config.oauth.CustomUserDetails;
 import com.potential_radar.PR.user.model.User;
-import com.potential_radar.PR.user.repository.UserRepository;
 import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -11,6 +11,8 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.stereotype.Service;
 
+import java.nio.charset.StandardCharsets;
+import java.security.Key;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.Date;
@@ -21,12 +23,25 @@ import java.util.Set;
 @Slf4j
 public class TokenProvider {
     private final JwtProperties jwtProperties;
-    private final UserRepository userRepository;
+    private Key secretKey;
 
+    @PostConstruct
+    public void init() {
+        byte[] keyBytes = jwtProperties.getSecretKey().getBytes(StandardCharsets.UTF_8);
+        this.secretKey = Keys.hmacShaKeyFor(keyBytes);
+    }
 
     public String generateToken(User user, Duration expiredAt) {
         Date now = new Date();
         return makeToken(new Date(now.getTime()+ expiredAt.toMillis()), user);
+    }
+
+    public String generateAccessToken(User user) {
+        return generateToken(user, Duration.ofMillis(jwtProperties.getAccessTokenExpiration()));
+    }
+
+    public String generateRefreshToken(User user) {
+        return generateToken(user, Duration.ofMillis(jwtProperties.getRefreshTokenExpiration()));
     }
 
     // JWT 토큰 생성 메서드
@@ -40,7 +55,7 @@ public class TokenProvider {
                 .setExpiration(expiredAt)
                 .setSubject(user.getEmail())
                 .claim("id", user.getUserId())
-                .signWith(SignatureAlgorithm.HS256, jwtProperties.getSecretKey())
+                .signWith(secretKey, SignatureAlgorithm.HS256)
                 .compact();
     }
 
@@ -49,20 +64,23 @@ public class TokenProvider {
     public boolean validToken(String token) {
         try {
             Jwts.parser()
-                    .setSigningKey(jwtProperties.getSecretKey())
+                    .setSigningKey(secretKey)
                     .parseClaimsJws(token);
 
             return true;
         }catch (ExpiredJwtException e) {
-            // 만료된 토큰 로깅
-            log.warn("⚠️ Token expired : {}",e.getMessage());
+            log.warn("⚠️ Expired JWT token: {}", e.getMessage());
             return false;
-        }catch(JwtException e) {
-            // JWT 관련 예외 로깅
-            log.warn("❌ Token invalid : {}",e.getMessage());
+        } catch (SecurityException | MalformedJwtException e) {
+            log.warn("❌ Malformed JWT token: {}", e.getMessage());
             return false;
-        }catch(Exception e) {
-            // 예상치 못한 예외 로깅
+        } catch (UnsupportedJwtException e) {
+            log.warn("Unsupported JWT token: {}", e.getMessage());
+            return false;
+        } catch (IllegalArgumentException e) {
+            log.warn("JWT claims string is empty: {}", e.getMessage());
+            return false;
+        } catch(Exception e) {
             log.error("🔥 Unexpected error during token validation : {}",e.getMessage());
             return false;
         }
@@ -71,20 +89,10 @@ public class TokenProvider {
     // 토큰 기반으로 인증 정보를 가져오는 메서드
     public Authentication getAuthentication(String token) {
         Claims claims = getClaims(token);
-        String email = claims.getSubject();
+        // 토큰에서 권한 정보를 추출하거나 사용자별 권한 조회
+        Set<SimpleGrantedAuthority> authorities = Collections.singleton(new SimpleGrantedAuthority("ROLE_USER"));
 
-        // ✅ DB에서 사용자 조회
-        User user = userRepository.findByEmail(email)
-                .orElseThrow(() -> new RuntimeException("유저를 찾을 수 없습니다."));
-
-        // ✅ CustomUserDetails 생성
-        CustomUserDetails userDetails = new CustomUserDetails(user);
-
-        return new UsernamePasswordAuthenticationToken(
-                userDetails,
-                null,
-                userDetails.getAuthorities()
-        );
+        return new UsernamePasswordAuthenticationToken(new org.springframework.security.core.userdetails.User(claims.getSubject(),"",authorities), null, authorities);
     }
 
     // 토큰 기반으로 유저 ID를 가져오는 메서드
@@ -97,7 +105,7 @@ public class TokenProvider {
     private Claims getClaims(String token) {
         try{
             return Jwts.parser()
-                    .setSigningKey(jwtProperties.getSecretKey())
+                    .setSigningKey(secretKey)
                     .parseClaimsJws(token)
                     .getBody();
         }catch (JwtException e) {

--- a/src/main/java/com/potential_radar/PR/config/jwt/TokenProvider.java
+++ b/src/main/java/com/potential_radar/PR/config/jwt/TokenProvider.java
@@ -29,13 +29,19 @@ public class TokenProvider {
 
     @PostConstruct
     public void init() {
+        if (jwtProperties.getSecretKey() == null || jwtProperties.getSecretKey().isEmpty()) {
+            throw new IllegalStateException("JWT secret key must not be null or empty");
+        }
         byte[] keyBytes = jwtProperties.getSecretKey().getBytes(StandardCharsets.UTF_8);
+        if (keyBytes.length < 32) {
+            throw new IllegalStateException("JWT secret key must be at least 256 bits");
+        }
         this.secretKey = Keys.hmacShaKeyFor(keyBytes);
     }
 
     public String generateToken(User user, Duration expiredAt) {
         Date now = new Date();
-        return makeToken(new Date(now.getTime()+ expiredAt.toMillis()), user);
+        return makeToken(new Date(now.getTime() + expiredAt.toMillis()), user);
     }
 
     public String generateAccessToken(User user) {
@@ -66,7 +72,7 @@ public class TokenProvider {
                     .parseClaimsJws(token);
 
             return true;
-        }catch (ExpiredJwtException e) {
+        } catch (ExpiredJwtException e) {
             log.warn("⚠️ Expired JWT token: {}", e.getMessage());
             return false;
         } catch (SecurityException | MalformedJwtException e) {
@@ -78,8 +84,8 @@ public class TokenProvider {
         } catch (IllegalArgumentException e) {
             log.warn("JWT claims string is empty: {}", e.getMessage());
             return false;
-        } catch(Exception e) {
-            log.error("🔥 Unexpected error during token validation : {}",e.getMessage());
+        } catch (Exception e) {
+            log.error("🔥 Unexpected error during token validation : {}", e.getMessage());
             return false;
         }
     }
@@ -90,7 +96,7 @@ public class TokenProvider {
         // 토큰에서 권한 정보를 추출하거나 사용자별 권한 조회
         Set<SimpleGrantedAuthority> authorities = Collections.singleton(new SimpleGrantedAuthority("ROLE_USER"));
 
-        return new UsernamePasswordAuthenticationToken(new org.springframework.security.core.userdetails.User(claims.getSubject(),"",authorities), null, authorities);
+        return new UsernamePasswordAuthenticationToken(new org.springframework.security.core.userdetails.User(claims.getSubject(), "", authorities), null, authorities);
     }
 
     // 토큰 기반으로 유저 ID를 가져오는 메서드
@@ -101,13 +107,13 @@ public class TokenProvider {
 
 
     private Claims getClaims(String token) {
-        try{
+        try {
             return Jwts.parser()
                     .setSigningKey(secretKey)
                     .parseClaimsJws(token)
                     .getBody();
-        }catch (JwtException e) {
-            throw new IllegalArgumentException("Invalid JWT token",e);
+        } catch (JwtException e) {
+            throw new IllegalArgumentException("Invalid JWT token", e);
 
         }
     }

--- a/src/main/java/com/potential_radar/PR/config/jwt/TokenProvider.java
+++ b/src/main/java/com/potential_radar/PR/config/jwt/TokenProvider.java
@@ -4,6 +4,7 @@ import com.potential_radar.PR.user.model.User;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
 import jakarta.annotation.PostConstruct;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -21,6 +22,7 @@ import java.util.Set;
 @RequiredArgsConstructor
 @Service
 @Slf4j
+@Getter
 public class TokenProvider {
     private final JwtProperties jwtProperties;
     private Key secretKey;
@@ -38,10 +40,6 @@ public class TokenProvider {
 
     public String generateAccessToken(User user) {
         return generateToken(user, Duration.ofMillis(jwtProperties.getAccessTokenExpiration()));
-    }
-
-    public String generateRefreshToken(User user) {
-        return generateToken(user, Duration.ofMillis(jwtProperties.getRefreshTokenExpiration()));
     }
 
     // JWT 토큰 생성 메서드

--- a/src/main/java/com/potential_radar/PR/config/oauth/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/com/potential_radar/PR/config/oauth/OAuth2AuthenticationSuccessHandler.java
@@ -3,6 +3,7 @@ package com.potential_radar.PR.config.oauth;
 import com.potential_radar.PR.config.jwt.TokenProvider;
 import com.potential_radar.PR.user.model.User;
 import com.potential_radar.PR.user.repository.UserRepository;
+import com.potential_radar.PR.user.service.RefreshTokenService;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
@@ -10,14 +11,13 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.security.core.Authentication; // ✅ 올바른 Authentication import
+import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
-import java.time.Duration;
 import java.util.Map;
 
 @Slf4j
@@ -27,6 +27,7 @@ public class OAuth2AuthenticationSuccessHandler implements AuthenticationSuccess
 
     private final TokenProvider tokenProvider;
     private final UserRepository userRepository;
+    private final RefreshTokenService refreshTokenService;
 
     @Value("${app.frontend-redirect-url}")
     private String frontendCallbackUrl;
@@ -59,27 +60,21 @@ public class OAuth2AuthenticationSuccessHandler implements AuthenticationSuccess
                     log.error("❌ 가입된 유저가 없습니다: {}", email);
                     return new OAuth2AuthenticationException("가입된 유저가 없습니다.");                });
 
-        // JWT 생성
-        String jwt = tokenProvider.generateToken(user, Duration.ofHours(2));
+        // 로컬 로그인과 동일하게 Access Token과 Refresh Token을 모두 생성
+        String accessToken = tokenProvider.generateAccessToken(user);
+        String refreshToken = refreshTokenService.createAndSaveRefreshToken(user);
 
-        // ✅ 방법 1: 프론트로 리다이렉트 시 토큰을 쿼리로 전달
-        // 토큰을 HttpOnly 쿠키로 설정
-        Cookie tokenCookie = new Cookie("auth-token", jwt);
-                tokenCookie.setHttpOnly(true);
-                tokenCookie.setSecure(false); // HTTPS에서만 사용  ✅ 개발 중에는 false
-                tokenCookie.setPath("/");
-                tokenCookie.setMaxAge(7200); // 2시간
-                tokenCookie.setAttribute("SameSite", "Strict");    // SameSite=Strict 설정으로 CSRF 방지
-             response.addCookie(tokenCookie);
+        // Refresh Token은 보안을 위해 HttpOnly 쿠키로 전달
+        Cookie refreshTokenCookie = new Cookie("refresh_token", refreshToken);
+        refreshTokenCookie.setHttpOnly(true);
+        refreshTokenCookie.setSecure(true); // HTTPS 환경에서만 전송되도록 설정
+        refreshTokenCookie.setPath("/"); // 모든 경로에서 쿠키 사용
+        refreshTokenCookie.setMaxAge((int) (tokenProvider.getJwtProperties().getRefreshTokenExpiration() / 1000)); // 만료시간 설정 (초 단위)
+        response.addCookie(refreshTokenCookie);
 
-        // 설정에서 가져온 안전한 리다이렉트 URL 사용
-        String redirectWithToken = frontendCallbackUrl + "?token=" + jwt;
+        // Access Token은 프론트엔드가 바로 사용할 수 있도록 리다이렉트 URL의 쿼리 파라미터로 전달
+        String redirectWithToken = frontendCallbackUrl + "?accessToken=" + accessToken;
         response.sendRedirect(redirectWithToken);
-
-        // ✅ 방법 2: SPA용 JSON 응답
-//        response.setContentType("application/json;charset=UTF-8");
-//        response.getWriter().write("{\"token\": \"" + jwt + "\"}");
-//        response.getWriter().flush();
 
         log.info("✅ OAuth2 로그인 성공. JWT 발급 완료: {}", email);
     }

--- a/src/main/java/com/potential_radar/PR/user/controller/AuthController.java
+++ b/src/main/java/com/potential_radar/PR/user/controller/AuthController.java
@@ -27,8 +27,8 @@ public class AuthController {
     private final EmailAuthService emailAuthService;
 
     @PostMapping("/send-code")
-    public ResponseEntity<Void> sendVerificationCode(@Valid @RequestBody EmailRequest request) {
-        emailAuthService.sendVerificationCode(request.getEmail());
+    public ResponseEntity<?> sendVerificationCode(@Valid @RequestBody EmailRequest request) {
+        emailAuthService.validateAndSendCode(request.getEmail());
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/com/potential_radar/PR/user/controller/AuthController.java
+++ b/src/main/java/com/potential_radar/PR/user/controller/AuthController.java
@@ -39,7 +39,7 @@ public class AuthController {
     }
 
     @GetMapping("/check-nickname")
-    public ResponseEntity<Map<String, Boolean>> checkNickname(@RequestParam @NotBlank @Size(min = 2, max = 20) String nickname) {        boolean duplicate = userService.existsByNickName(nickname);
+    public ResponseEntity<Map<String, Boolean>> checkNickname(@RequestParam @NotBlank @Size(min = 2, max = 20) String nickname) {        boolean duplicate = userService.existsbynickname(nickname);
         return ResponseEntity.ok(Map.of("duplicate", duplicate));
 
     }

--- a/src/main/java/com/potential_radar/PR/user/controller/TokenApiController.java
+++ b/src/main/java/com/potential_radar/PR/user/controller/TokenApiController.java
@@ -19,14 +19,9 @@ public class TokenApiController {
 
     @PostMapping("/api/token")
     public ResponseEntity<CreateAccessTokenResponse> createNewAccessToken(@Valid @RequestBody CreateAccessTokenRequest request){
-        try{
-            String newAccessToken = tokenService.createNewAccessToken(request.getRefreshToken());
-
-            return ResponseEntity.status(HttpStatus.CREATED).body(new CreateAccessTokenResponse(newAccessToken));
-        }catch (IllegalArgumentException e) {
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
-        }catch (Exception e) {
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
-        }
+        // IllegalArgumentException은 유효하지 않거나 만료된 토큰을 의미하므로 401 Unauthorized가 더 적절합니다.
+        String newAccessToken = tokenService.createNewAccessToken(request.getRefreshToken());
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(new CreateAccessTokenResponse(newAccessToken));
     }
 }

--- a/src/main/java/com/potential_radar/PR/user/controller/UserController.java
+++ b/src/main/java/com/potential_radar/PR/user/controller/UserController.java
@@ -27,46 +27,27 @@ public class UserController {
 
     @PostMapping("/login")
     public ResponseEntity<Object> login(@RequestBody UserLoginRequest loginRequest) {
-        try{
-
-            LoginResponse tokens= userService.login(loginRequest);
-            return ResponseEntity.status(HttpStatus.OK).body(tokens);
-
-        }catch (IllegalArgumentException e){
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(e.getMessage());
-        }catch (Exception e){
-            log.error("🔥 로그인 처리 중 서버 오류", e); // 전체 스택 트레이스 보기
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("로그인 처리 중 오류가 발생했습니다");
-        }
+        LoginResponse tokens = userService.login(loginRequest);
+        return ResponseEntity.status(HttpStatus.OK).body(tokens);
     }
 
     @PostMapping("/signup")
     public ResponseEntity<Object> signup(@Valid @RequestBody UserSignupRequest request) {
-        try{
-            User newUser = userService.register(request);
-            return ResponseEntity.ok().body(Map.of("message", "회원가입 성공",
-                    "userId", newUser.getUserId()));
-        }catch (IllegalArgumentException e){
-            return ResponseEntity.badRequest().body(e.getMessage());
-        }catch (Exception e){
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("회원가입 처리 중 오류가 발생했습니다");
-        }
+        User newUser = userService.register(request);
+        return ResponseEntity.ok().body(Map.of("message", "회원가입 성공",
+                "userId", newUser.getUserId()));
     }
 
 
     @PostMapping("/logout")
     public ResponseEntity<Object> logout(Principal principal) {
-        try {
-            if (principal == null) {
-                return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("인증되지 않은 사용자입니다.");
-            }
-            String email = principal.getName();
-            User user = userService.findByEmail(email);
-            tokenService.deleteRefreshToken(user.getUserId());
-            return ResponseEntity.ok("로그아웃 성공");
-
-        }catch (Exception e){
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("로그아웃 처리 중 오류가 발생했습니다");
+        if (principal == null) {
+            // Spring Security의 FilterChain에서 처리되지만, 만약을 위한 방어 코드
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("인증되지 않은 사용자입니다.");
         }
+        String email = principal.getName();
+        User user = userService.findByEmail(email);
+        tokenService.deleteRefreshToken(user.getUserId());
+        return ResponseEntity.ok("로그아웃 성공");
     }
 }

--- a/src/main/java/com/potential_radar/PR/user/controller/UserController.java
+++ b/src/main/java/com/potential_radar/PR/user/controller/UserController.java
@@ -69,8 +69,4 @@ public class UserController {
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("로그아웃 처리 중 오류가 발생했습니다");
         }
     }
-
-    // 모든 인증이 필요한 요청에선 Authorization: Bearer {AccessToken} 헤더 사용
-
-
 }

--- a/src/main/java/com/potential_radar/PR/user/dto/EmailRequest.java
+++ b/src/main/java/com/potential_radar/PR/user/dto/EmailRequest.java
@@ -1,8 +1,13 @@
 package com.potential_radar.PR.user.dto;
 
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
 import lombok.Data;
 
 @Data
 public class EmailRequest {
+
+    @NotBlank(message = "이메일은 필수 입력 값입니다.")
+    @Email(message = "유효한 이메일 형식이 아닙니다.")
     private String email;
 }

--- a/src/main/java/com/potential_radar/PR/user/dto/EmailVerificationRequest.java
+++ b/src/main/java/com/potential_radar/PR/user/dto/EmailVerificationRequest.java
@@ -1,9 +1,15 @@
 package com.potential_radar.PR.user.dto;
 
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
 import lombok.Data;
 
 @Data
 public class EmailVerificationRequest {
+    @NotBlank(message = "이메일은 필수 입력 값입니다.")
+    @Email(message = "유효한 이메일 형식이 아닙니다.")
     private String email;
+
+    @NotBlank(message = "인증 코드는 필수 입력 값입니다.")
     private String code;
 }

--- a/src/main/java/com/potential_radar/PR/user/model/EmailVerification.java
+++ b/src/main/java/com/potential_radar/PR/user/model/EmailVerification.java
@@ -3,7 +3,6 @@ package com.potential_radar.PR.user.model;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.cglib.core.Local;
 
 import java.time.LocalDateTime;
 
@@ -30,9 +29,5 @@ public class EmailVerification {
         this.email = email;
         this.code = code;
         this.createdAt = LocalDateTime.now();
-    }
-
-    public boolean isExpired() {
-        return createdAt.isBefore(LocalDateTime.now().minusMinutes(3));
     }
 }

--- a/src/main/java/com/potential_radar/PR/user/model/RefreshToken.java
+++ b/src/main/java/com/potential_radar/PR/user/model/RefreshToken.java
@@ -5,6 +5,8 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.Instant;
+
 @Entity
 @Table(name = "refresh_tokens")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -21,13 +23,23 @@ public class RefreshToken {
     @Column(name="refresh_token", nullable = false)
     private String refreshToken;
 
-    public RefreshToken(Long userId, String refreshToken) {
+    @Column(name="expiry_date", nullable = false)
+    private Instant expiryDate;
+
+    public RefreshToken(Long userId, String refreshToken, Instant expiryDate) {
         this.userId = userId;
         this.refreshToken = refreshToken;
+        this.expiryDate = expiryDate;
     }
 
-    public RefreshToken update(String newRefreshToken) {
+    public RefreshToken update(String newRefreshToken, Instant newExpiryDate) {
         this.refreshToken = newRefreshToken;
+        this.expiryDate = newExpiryDate;
         return this;
+    }
+
+    public boolean isExpired(){
+
+        return this.expiryDate.isBefore(Instant.now());
     }
 }

--- a/src/main/java/com/potential_radar/PR/user/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/potential_radar/PR/user/service/CustomOAuth2UserService.java
@@ -28,8 +28,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
         String provider = userRequest.getClientRegistration().getRegistrationId(); // google, kakao
         OAuth2UserInfo userInfo = getOAuth2UserInfo(provider, oAuth2User.getAttributes());
 
-        // 회원가입 또는 기존 유저 조회
-        User user = saveOrUpdate(userInfo);
+        saveOrUpdate(userInfo);
 
         // Security 인증 객체 반환
         return new DefaultOAuth2User(

--- a/src/main/java/com/potential_radar/PR/user/service/EmailAuthService.java
+++ b/src/main/java/com/potential_radar/PR/user/service/EmailAuthService.java
@@ -1,10 +1,16 @@
 package com.potential_radar.PR.user.service;
 
 import com.potential_radar.PR.user.model.EmailVerification;
+import com.potential_radar.PR.user.model.User;
 import com.potential_radar.PR.user.repository.EmailVerificationRepository;
+import com.potential_radar.PR.user.repository.UserRepository;
+import java.time.LocalDateTime;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -15,9 +21,28 @@ import java.security.SecureRandom;
 public class EmailAuthService {
     private final EmailVerificationRepository emailVerificationRepository;
     private final JavaMailSender mailSender;
+    private final UserRepository userRepository;
 
+    @Value("${email.verification.expiration-minutes:3}")
+    private long expirationMinutes;
+
+    @Transactional(readOnly = true)
+    public void validateAndSendCode(String email) {
+        userRepository.findByEmail(email).ifPresent(user -> {
+            if (user.getProvider() != User.Provider.LOCAL) {
+                throw new IllegalArgumentException("이미 " + user.getProvider().name() + " 계정으로 가입된 이메일입니다. 소셜 로그인을 이용해주세요.");
+            } else {
+                throw new IllegalArgumentException("이미 가입된 이메일입니다.");
+            }
+        });
+
+        sendCodeAsync(email);
+    }
+
+
+    @Async
     @Transactional
-    public void sendVerificationCode(String email) {
+    public void sendCodeAsync(String email) {
         String code = String.format("%06d", new SecureRandom().nextInt(1000000));
 
         emailVerificationRepository.deleteByEmail(email);
@@ -26,16 +51,32 @@ public class EmailAuthService {
         SimpleMailMessage message = new SimpleMailMessage();
         message.setTo(email);
         message.setSubject("[PR] 이메일 인증번호");
-        message.setText("인증번호는 " + code + " 입니다. (3분 이내 입력)");
+        message.setText("인증번호는 " + code + " 입니다. (" + expirationMinutes + "분 이내 입력)");
 
         mailSender.send(message);
     }
 
+    @Transactional
     public boolean verifyCode(String email, String inputCode) {
-        return emailVerificationRepository.findByEmail(email)
-                .filter(v -> !v.isExpired())
-                .map(v -> v.getCode().equals(inputCode))
-                .orElse(false);
+        Optional<EmailVerification> verificationOpt = emailVerificationRepository.findByEmail(email);
+
+        if (verificationOpt.isEmpty()) {
+            return false; // 해당 이메일로 요청된 코드가 없음
+        }
+
+        EmailVerification verification = verificationOpt.get();
+        boolean isExpired = verification.getCreatedAt().isBefore(LocalDateTime.now().minusMinutes(expirationMinutes));
+
+        if (isExpired) {
+            emailVerificationRepository.delete(verification); // 만료된 코드는 삭제
+            return false; // 만료되었으므로 실패
+        }
+
+        boolean isCorrect = verification.getCode().equals(inputCode);
+        if (isCorrect) {
+            emailVerificationRepository.delete(verification); // 인증 성공 시 일회용으로 사용되도록 삭제
+        }
+        return isCorrect;
     }
 
 }

--- a/src/main/java/com/potential_radar/PR/user/service/RefreshTokenService.java
+++ b/src/main/java/com/potential_radar/PR/user/service/RefreshTokenService.java
@@ -1,16 +1,41 @@
 package com.potential_radar.PR.user.service;
 
+import com.potential_radar.PR.config.jwt.JwtProperties;
+import com.potential_radar.PR.config.jwt.TokenProvider;
 import com.potential_radar.PR.user.model.RefreshToken;
+import com.potential_radar.PR.user.model.User;
 import com.potential_radar.PR.user.repository.RefreshTokenRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.util.UUID;
 
 @RequiredArgsConstructor
 @Service
 public class RefreshTokenService {
     private final RefreshTokenRepository refreshTokenRepository;
+    private final JwtProperties jwtProperties;
 
+    @Transactional
     public RefreshToken findByRefreshToken(String refreshToken){
-        return refreshTokenRepository.findByRefreshToken(refreshToken).orElseThrow(()->new IllegalArgumentException("Unexpected Token"));
+        return refreshTokenRepository.findByRefreshToken(refreshToken)
+                .orElseThrow(()->new IllegalArgumentException("Unexpected Token"));
+    }
+
+    @Transactional
+    public String createAndSaveRefreshToken(User user) {
+        // 리프레시 토큰은 JWT 형식이 아니어도 되므로, 간단한 UUID를 사용하거나 필요시 JWT로 생성할 수 있습니다.
+        // 여기서는 간단한 UUID를 사용합니다.
+        String tokenValue = UUID.randomUUID().toString();
+        Instant expiryDate = Instant.now().plusMillis(jwtProperties.getRefreshTokenExpiration());
+
+        RefreshToken refreshToken = refreshTokenRepository.findByUserId(user.getUserId())
+                .map(entity -> entity.update(tokenValue, expiryDate))
+                .orElse(new RefreshToken(user.getUserId(), tokenValue, expiryDate));
+
+        refreshTokenRepository.save(refreshToken);
+        return tokenValue;
     }
 }

--- a/src/main/java/com/potential_radar/PR/user/service/TokenService.java
+++ b/src/main/java/com/potential_radar/PR/user/service/TokenService.java
@@ -1,12 +1,12 @@
 package com.potential_radar.PR.user.service;
 
 import com.potential_radar.PR.config.jwt.TokenProvider;
+import com.potential_radar.PR.user.model.RefreshToken;
 import com.potential_radar.PR.user.model.User;
 import com.potential_radar.PR.user.repository.RefreshTokenRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-
-import java.time.Duration;
+import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
 @Service
@@ -17,18 +17,24 @@ public class TokenService {
     private final UserService userService;
     private final RefreshTokenRepository refreshTokenRepository;
 
+    @Transactional
     public String createNewAccessToken(String refreshToken){
-        // 토큰 유효성 검사에 실패하면 예외 발생
-        if(!tokenProvider.validToken(refreshToken)){
-            throw new IllegalArgumentException("Invalid Refresh Token");
+        // DB에서 리프레시 토큰을 찾아 유효성 검증
+        RefreshToken foundRefreshToken = refreshTokenService.findByRefreshToken(refreshToken);
+
+        // 리프레시 토큰이 만료되었는지 확인
+        if (foundRefreshToken.isExpired()) {
+            refreshTokenRepository.delete(foundRefreshToken); // 만료된 토큰은 삭제
+            throw new IllegalArgumentException("Expired refresh token, please log in again.");
         }
 
-        Long userId = refreshTokenService.findByRefreshToken(refreshToken).getUserId();
+        Long userId = foundRefreshToken.getUserId();
         User user = userService.findById(userId);
 
-        return tokenProvider.generateToken(user, Duration.ofHours(2));
+        return tokenProvider.generateAccessToken(user);
     }
 
+    @Transactional
     public void deleteRefreshToken(Long userId) {
         refreshTokenRepository.findByUserId(userId).ifPresent(refreshTokenRepository::delete);
     }

--- a/src/main/java/com/potential_radar/PR/user/service/TokenService.java
+++ b/src/main/java/com/potential_radar/PR/user/service/TokenService.java
@@ -1,6 +1,7 @@
 package com.potential_radar.PR.user.service;
 
 import com.potential_radar.PR.config.jwt.TokenProvider;
+import com.potential_radar.PR.common.excetpion.InvalidTokenException;
 import com.potential_radar.PR.user.model.RefreshToken;
 import com.potential_radar.PR.user.model.User;
 import com.potential_radar.PR.user.repository.RefreshTokenRepository;
@@ -25,7 +26,7 @@ public class TokenService {
         // 리프레시 토큰이 만료되었는지 확인
         if (foundRefreshToken.isExpired()) {
             refreshTokenRepository.delete(foundRefreshToken); // 만료된 토큰은 삭제
-            throw new IllegalArgumentException("Expired refresh token, please log in again.");
+            throw new InvalidTokenException("만료된 리프레시 토큰입니다. 다시 로그인해주세요.");
         }
 
         Long userId = foundRefreshToken.getUserId();

--- a/src/main/java/com/potential_radar/PR/user/service/TokenService.java
+++ b/src/main/java/com/potential_radar/PR/user/service/TokenService.java
@@ -7,6 +7,7 @@ import com.potential_radar.PR.user.model.User;
 import com.potential_radar.PR.user.repository.RefreshTokenRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
@@ -18,8 +19,8 @@ public class TokenService {
     private final UserService userService;
     private final RefreshTokenRepository refreshTokenRepository;
 
-    @Transactional
-    public String createNewAccessToken(String refreshToken){
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public String createNewAccessToken(String refreshToken) {
         // DB에서 리프레시 토큰을 찾아 유효성 검증
         RefreshToken foundRefreshToken = refreshTokenService.findByRefreshToken(refreshToken);
 

--- a/src/main/java/com/potential_radar/PR/user/service/UserService.java
+++ b/src/main/java/com/potential_radar/PR/user/service/UserService.java
@@ -4,9 +4,6 @@ import com.potential_radar.PR.user.dto.LoginResponse;
 import com.potential_radar.PR.user.dto.UserLoginRequest;
 import com.potential_radar.PR.user.dto.UserSignupRequest;
 import com.potential_radar.PR.user.model.User;
-import org.springframework.stereotype.Service;
-
-import java.util.Optional;
 
 
 public interface UserService {
@@ -21,6 +18,6 @@ public interface UserService {
 
     LoginResponse login(UserLoginRequest request);
 
-    boolean existsByNickName(String nickname);
+    boolean existsbynickname(String nickname);
 
 }

--- a/src/main/java/com/potential_radar/PR/user/service/UserServiceImpl.java
+++ b/src/main/java/com/potential_radar/PR/user/service/UserServiceImpl.java
@@ -1,5 +1,6 @@
 package com.potential_radar.PR.user.service;
 
+import com.potential_radar.PR.common.excetpion.NotFoundException;
 import com.potential_radar.PR.config.jwt.TokenProvider;
 import com.potential_radar.PR.user.dto.LoginResponse;
 import com.potential_radar.PR.user.dto.UserLoginRequest;
@@ -49,12 +50,12 @@ public class UserServiceImpl implements UserService {
     }
 
     public User findById(Long userId){
-        return userRepository.findById(userId).orElseThrow(()->new IllegalArgumentException("Unexpected User"));
+        return userRepository.findById(userId).orElseThrow(()->new NotFoundException("사용자를 찾을 수 없습니다. ID: " + userId));
     }
 
     @Override
     public User findByEmail(String email) {
-        return userRepository.findByEmail(email).orElseThrow(()->new IllegalArgumentException("Unexpected User"));
+        return userRepository.findByEmail(email).orElseThrow(()->new NotFoundException("사용자를 찾을 수 없습니다. 이메일: " + email));
     }
 
     @Override

--- a/src/main/java/com/potential_radar/PR/user/service/UserServiceImpl.java
+++ b/src/main/java/com/potential_radar/PR/user/service/UserServiceImpl.java
@@ -79,7 +79,7 @@ public class UserServiceImpl implements UserService {
     }
 
     @Override
-    public boolean existsByNickName(String nickname) {
+    public boolean existsbynickname(String nickname) {
         return userRepository.existsByNickname(nickname);
     }
 

--- a/src/main/java/com/potential_radar/PR/user/service/UserServiceImpl.java
+++ b/src/main/java/com/potential_radar/PR/user/service/UserServiceImpl.java
@@ -4,16 +4,12 @@ import com.potential_radar.PR.config.jwt.TokenProvider;
 import com.potential_radar.PR.user.dto.LoginResponse;
 import com.potential_radar.PR.user.dto.UserLoginRequest;
 import com.potential_radar.PR.user.dto.UserSignupRequest;
-import com.potential_radar.PR.user.model.RefreshToken;
 import com.potential_radar.PR.user.model.User;
-import com.potential_radar.PR.user.repository.RefreshTokenRepository;
 import com.potential_radar.PR.user.repository.UserRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
-
-import java.time.Duration;
 
 
 @Service
@@ -24,7 +20,7 @@ public class UserServiceImpl implements UserService {
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
     private final TokenProvider tokenProvider;
-    private final RefreshTokenRepository refreshTokenRepository;
+    private final RefreshTokenService refreshTokenService;
 
     @Override
     public User register(UserSignupRequest request) {
@@ -41,7 +37,7 @@ public class UserServiceImpl implements UserService {
                 .provider(User.Provider.LOCAL)
                 .reputationScore(null)
                 .reviewCount(0)
-        .build();
+                .build();
 
 
         return userRepository.save(user);
@@ -63,7 +59,7 @@ public class UserServiceImpl implements UserService {
 
     @Override
     public LoginResponse login(UserLoginRequest request) {
-         // 1. 이메일로 유저 조회
+        // 1. 이메일로 유저 조회
         User user = userRepository.findByEmail(request.email())
                 .orElseThrow(()->new IllegalArgumentException("존재하지 않는 사용자입니다."));
 
@@ -72,24 +68,18 @@ public class UserServiceImpl implements UserService {
             throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
         }
 
-        // 3. 토큰 발급
-        String accessToken = tokenProvider.generateToken(user, Duration.ofMinutes(30));
-        String refreshToken = tokenProvider.generateToken(user, Duration.ofDays(14));
-
-        // 4. refreshToken 저장 또는 갱신
-        refreshTokenRepository.findByUserId(user.getUserId())
-                .ifPresentOrElse(
-                        rt -> rt.update(refreshToken),
-                        ()-> refreshTokenRepository.save(new RefreshToken(user.getUserId(), refreshToken))
-                );
+        // 3. 액세스 토큰 생성 (만료 시간은 JwtProperties에서 관리)
+        String accessToken = tokenProvider.generateAccessToken(user);
+        // 4. 리프레시 토큰 생성 및 저장 (UUID 기반, 로직은 RefreshTokenService에 위임)
+        String refreshToken = refreshTokenService.createAndSaveRefreshToken(user);
 
         // 5. 응답 반환
         return new LoginResponse(accessToken, refreshToken);
     }
 
     @Override
-    public boolean existsByNickName(String nickName) {
-        return userRepository.existsByNickname(nickName);
+    public boolean existsByNickName(String nickname) {
+        return userRepository.existsByNickname(nickname);
     }
 
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - OAuth2 로그인 시 액세스 토큰은 리다이렉트 파라미터로 전달되고, 리프레시 토큰은 HttpOnly·Secure 쿠키로 발급됩니다.
  - 리프레시 토큰을 DB에 저장·관리하여 재발급 흐름을 개선했습니다.
  - 이메일 입력에 대한 빈값/형식 검증과 만료 안내(기본 3분)를 추가했습니다.
  - 애플리케이션 시작 시 JWT 설정 유효성 검사를 도입했습니다.
- Bug Fixes
  - 리프레시 토큰 만료/무효를 감지해 삭제하고 재발급 흐름을 정비했습니다.
  - 에러 응답을 일관된 단일 메시지 형태로 통일하여 전역 예외 처리를 통합했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->