### PR TITLE
fix: TestDataInitializer 수정(createdAt 데이터)

### DIFF
--- a/src/main/java/com/potential_radar/PR/common/domain/BaseTimeEntity.java
+++ b/src/main/java/com/potential_radar/PR/common/domain/BaseTimeEntity.java
@@ -1,6 +1,7 @@
 package com.potential_radar.PR.common.domain;
 
 import jakarta.persistence.MappedSuperclass;
+import jakarta.persistence.PrePersist;
 import lombok.Getter;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
@@ -10,9 +11,22 @@ import java.time.LocalDateTime;
 @Getter
 @MappedSuperclass
 public class BaseTimeEntity {
-    @CreationTimestamp
+
     private LocalDateTime createdAt;
 
     @UpdateTimestamp
     private LocalDateTime updatedAt;
+
+    // createdAt 필드에 값을 직접 할당할 수 있도록 Setter 추가
+    public void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    // createdAt 값이 null일 경우에만 현재 시간을 할당
+    @PrePersist
+    public void prePersist() {
+        if (this.createdAt == null) {
+            this.createdAt = LocalDateTime.now();
+        }
+    }
 }

--- a/src/main/java/com/potential_radar/PR/config/TestDataInitializer.java
+++ b/src/main/java/com/potential_radar/PR/config/TestDataInitializer.java
@@ -441,8 +441,14 @@ public class TestDataInitializer implements CommandLineRunner {
                 .endDate(endDate)
                 .status(ProjectStatus.values()[random.nextInt(ProjectStatus.values().length)])
                 .viewCount(random.nextInt(500))
+                .recruitCount(random.nextInt(5) + 3)
                 .build();
-            
+
+
+            // save 이전에 createdAt 값을 직접 설정
+            project.setCreatedAt(LocalDateTime.now().minusDays(random.nextInt(365)));
+
+
             project = projectRecruitmentRepository.save(project);
             
             // 프로젝트 기술 파트 연결 (1-3개 랜덤 선택)


### PR DESCRIPTION
projectRecruitment에 createdAt 데이터 안 들어가는 문제 해결

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 프로젝트 모집에 모집 인원 정보가 제공됩니다. 목록/상세 화면에서 모집 인원을 확인할 수 있습니다.
- 리팩터
  - 생성일 기본값 처리 방식을 개선하여 데이터 기록의 일관성과 신뢰성을 강화했습니다.
- 작업
  - 테스트/시드 데이터에 현실적인 생성일(최근 1년 내 랜덤)과 모집 인원을 포함해 목록 정렬과 시나리오 테스트의 품질을 향상했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->