### PR TITLE
fix: Update UserReviewService

### DIFF
--- a/src/main/java/com/potential_radar/PR/user/service/UserReviewService.java
+++ b/src/main/java/com/potential_radar/PR/user/service/UserReviewService.java
@@ -21,17 +21,25 @@ public class UserReviewService {
         List<TeamMemberReview> reviews = teamMemberReviewRepository.findAllByRevieweeIdWithDetails(userId);
         
         return reviews.stream()
-                .map(review -> UserReceivedReviewResponse.builder()
-                        .reviewId(review.getId())
-                        .projectId(review.getProject().getProjectId())
-                        .projectTitle(review.getProject().getTitle())
-                        .reviewerId(review.getReviewer().getUserId())
-                        .reviewerNickname(review.getReviewer().getNickname())
-                        .reviewerProfileImage(review.getReviewer().getProfileImage())
-                        .rating(review.getRating())
-                        .comment(review.getComment())
-                        .createdAt(review.getCreatedAt())
-                        .build())
+                .map(review -> {
+                    String profileImage = review.getReviewer().getProfileImage();
+                    // 프로필 이미지가 null이거나 비어있으면 기본 아바타 URL 설정
+                    if (profileImage == null || profileImage.trim().isEmpty()) {
+                        profileImage = "https://api.dicebear.com/7.x/avataaars/svg?seed=" + review.getReviewer().getUserId();
+                    }
+                    
+                    return UserReceivedReviewResponse.builder()
+                            .reviewId(review.getId())
+                            .projectId(review.getProject().getProjectId())
+                            .projectTitle(review.getProject().getTitle())
+                            .reviewerId(review.getReviewer().getUserId())
+                            .reviewerNickname(review.getReviewer().getNickname())
+                            .reviewerProfileImage(profileImage)
+                            .rating(review.getRating())
+                            .comment(review.getComment())
+                            .createdAt(review.getCreatedAt())
+                            .build();
+                })
                 .collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
- 프로필 이미지 null 값 기본값으로 넣음

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 버그 수정
  - 리뷰 받은 목록에서 리뷰어의 프로필 이미지가 비어 있거나 누락된 경우, 사용자 ID 기반 기본 아바타가 자동으로 표시됩니다. 깨진 이미지가 사라져 목록의 시각적 일관성과 가독성이 개선됩니다. 기존 기능 동작과 응답 형식은 그대로 유지됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->